### PR TITLE
[WEBSITE-2172] '.' Address workaround

### DIFF
--- a/lib/parliament/grom/decorator/contact_point.rb
+++ b/lib/parliament/grom/decorator/contact_point.rb
@@ -3,32 +3,36 @@ module Parliament
     module Decorator
       # Decorator namespace for Grom::Node instances with type: https://id.parliament.uk/schema/ContactPoint
       module ContactPoint
+        # A hack has been added to postal_addresses, email, phone_number and fax_number
+        # to remove any details that are less than ATTRIBUTE_LENGTH_LIMIT_HACK in length
+        # including "." and "-" addresses when these have been mistakenly entered into Mnis
+        ATTRIBUTE_LENGTH_LIMIT_HACK = 1
         # Alias contactPointHasPostalAddress with fallback.
         #
         # @return [Array, Array] an array of the postal addresses for the Grom::Node or an empty array.
         def postal_addresses
-          respond_to?(:contactPointHasPostalAddress) ? contactPointHasPostalAddress : []
+          @postal_addresses ||= respond_to?(:contactPointHasPostalAddress) ? contactPointHasPostalAddress.reject { |address| address.full_address.length <= ATTRIBUTE_LENGTH_LIMIT_HACK } : []
         end
 
         # Alias email with fallback.
         #
         # @return [String, String] the email of the Grom::Node or an empty string.
         def email
-          instance_variable_get('@email'.to_sym).nil? ? '' : instance_variable_get('@email'.to_sym).strip
+          @email_decorator ||= instance_variable_get('@email'.to_sym) && instance_variable_get('@email'.to_sym).length > ATTRIBUTE_LENGTH_LIMIT_HACK ? instance_variable_get('@email'.to_sym).strip : ''
         end
 
         # Alias phoneNumber with fallback.
         #
         # @return [String, String] the phone number of the Grom::Node or an empty string.
         def phone_number
-          respond_to?(:phoneNumber) ? phoneNumber : ''
+          @phone_number ||= respond_to?(:phoneNumber) && phoneNumber.length > ATTRIBUTE_LENGTH_LIMIT_HACK ? phoneNumber : ''
         end
 
         # Alias faxNumber with fallback.
         #
         # @return [String, String] the fax number of the Grom::Node or an empty string.
         def fax_number
-          respond_to?(:faxNumber) ? faxNumber : ''
+          @fax_number ||= respond_to?(:faxNumber) && faxNumber.length > ATTRIBUTE_LENGTH_LIMIT_HACK ? faxNumber : ''
         end
 
         # Alias contactPointHasPerson with fallback.

--- a/lib/parliament/grom/decorator/version.rb
+++ b/lib/parliament/grom/decorator/version.rb
@@ -1,7 +1,7 @@
 module Parliament
   module Grom
     module Decorator
-      VERSION = '0.18.1'.freeze
+      VERSION = '0.19.0'.freeze
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_an_empty_string_for_email_addresses_that_are_less_than_the_length_limit.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_an_empty_string_for_email_addresses_that_are_less_than_the_length_limit.yml
@@ -33,14 +33,16 @@ http_interactions:
       encoding: UTF-8
       string: "<https://id.parliament.uk/fy1cWNCD>
         <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
-        .\r\n<https://id.parliament.uk/fy1cWNCD>
-        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \".\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 5678 910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
         <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
         .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
         <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
         <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
         <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
-        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" .>
+        .\r\n"
     http_version:
-  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
+  recorded_at: Thu, 15 Mar 2018 16:22:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_the_email_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_the_email_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,66 +19,29 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_the_email_stripped_of_whitespace_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_email/Grom_Node_has_all_the_required_objects/returns_the_email_stripped_of_whitespace_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,66 +19,29 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> " person@parliament.uk " .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \" emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Fri, 16 Mar 2018 11:24:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_fax_number/Grom_Node_has_all_the_required_objects/returns_an_empty_string_for_fax_numbers_that_are_less_than_the_length_limit.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_fax_number/Grom_Node_has_all_the_required_objects/returns_an_empty_string_for_fax_numbers_that_are_less_than_the_length_limit.yml
@@ -33,8 +33,9 @@ http_interactions:
       encoding: UTF-8
       string: "<https://id.parliament.uk/fy1cWNCD>
         <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
-        .\r\n<https://id.parliament.uk/fy1cWNCD>
-        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/faxNumber> \"-\" .\r\n<https://id.parliament.uk/fy1cWNCD>
         <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
         .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
         <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
@@ -42,5 +43,5 @@ http_interactions:
         <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
         <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
+  recorded_at: Thu, 15 Mar 2018 16:26:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_fax_number/Grom_Node_has_all_the_required_objects/returns_the_fax_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_fax_number/Grom_Node_has_all_the_required_objects/returns_the_fax_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,67 +19,29 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "example@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/faxNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/faxNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_fax_number/Grom_Node_has_no_fax_number/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_fax_number/Grom_Node_has_no_fax_number/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,66 +19,29 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_parliamentary_incumbency/Grom_Node_has_all_the_required_objects/returns_the_object_of_type_ParliamentaryIncumbency_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_parliamentary_incumbency/Grom_Node_has_all_the_required_objects/returns_the_object_of_type_ParliamentaryIncumbency_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,68 +19,31 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c123> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c123> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ParliamentaryIncumbency> .
-
+      string: "<https://id.parliament.uk/43RHonMf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Person> .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/contactPointHasParliamentaryIncumbency> <https://id.parliament.uk/5b1mxVJ7> .\r\n<https://id.parliament.uk/5b1mxVJ7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ParliamentaryIncumbency>
+        .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_parliamentary_incumbency/Grom_Node_has_no_parliamentary_incumbency_associated_with_it/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_parliamentary_incumbency/Grom_Node_has_no_parliamentary_incumbency_associated_with_it/returns_nil.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,56 +19,31 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
+      string: "<https://id.parliament.uk/43RHonMf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Person> 
+        .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_person/Grom_Node_has_all_the_required_objects/returns_the_object_of_type_Person_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_person/Grom_Node_has_all_the_required_objects/returns_the_object_of_type_Person_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,67 +19,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPerson> <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/43RHonMf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Person> .\r\n<https://id.parliament.uk/43RHonMf>
+        <https://id.parliament.uk/schema/personGivenName> \"FirstName\" .\r\n<https://id.parliament.uk/43RHonMf>
+        <https://id.parliament.uk/schema/personOtherNames> \"MiddleName\" .\r\n<https://id.parliament.uk/43RHonMf>
+        <https://id.parliament.uk/schema/personFamilyName> \"LastName\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/contactPointHasPerson> <https://id.parliament.uk/43RHonMf>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_person/Grom_Node_has_no_person_associated_with_it/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_person/Grom_Node_has_no_person_associated_with_it/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,59 +19,29 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_phone_number/Grom_Node_has_all_the_required_objects/returns_an_empty_string_for_phone_numbers_that_are_less_than_the_length_limit.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_phone_number/Grom_Node_has_all_the_required_objects/returns_an_empty_string_for_phone_numbers_that_are_less_than_the_length_limit.yml
@@ -33,8 +33,9 @@ http_interactions:
       encoding: UTF-8
       string: "<https://id.parliament.uk/fy1cWNCD>
         <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
-        .\r\n<https://id.parliament.uk/fy1cWNCD>
-        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"-\" .\r\n<https://id.parliament.uk/fy1cWNCD>
         <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
         .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
         <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
@@ -42,5 +43,5 @@ http_interactions:
         <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
         <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
+  recorded_at: Thu, 15 Mar 2018 16:24:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_phone_number/Grom_Node_has_all_the_required_objects/returns_the_phone_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_phone_number/Grom_Node_has_all_the_required_objects/returns_the_phone_number_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,66 +19,29 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_phone_number/Grom_Node_has_no_phone_number/returns_an_empty_string.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_phone_number/Grom_Node_has_no_phone_number/returns_an_empty_string.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,65 +19,28 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "person@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_postal_addresses/Grom_Node_has_all_the_required_objects/returns_an_empty_array_for_postal_addresses_with_a_full_address_that_is_less_than_the_length_limit.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_postal_addresses/Grom_Node_has_all_the_required_objects/returns_an_empty_array_for_postal_addresses_with_a_full_address_that_is_less_than_the_length_limit.yml
@@ -33,14 +33,13 @@ http_interactions:
       encoding: UTF-8
       string: "<https://id.parliament.uk/fy1cWNCD>
         <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
-        .\r\n<https://id.parliament.uk/fy1cWNCD>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
         <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
         <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
         .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
         <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
-        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
-        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
-        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
+        <https://id.parliament.uk/schema/addressLine1> \".\" .\r\n"
     http_version:
-  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
+  recorded_at: Thu, 15 Mar 2018 16:19:36 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_postal_addresses/Grom_Node_has_all_the_required_objects/returns_the_postal_addresses_for_a_Grom_Node_object_of_type_ContactPoint.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_postal_addresses/Grom_Node_has_all_the_required_objects/returns_the_postal_addresses_for_a_Grom_Node_object_of_type_ContactPoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,66 +19,29 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "example@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PostalAddress> .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine1> "House of Commons" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/addressLine2> "London" .
-        <https://id.parliament.uk/0edc6f22-9465-452e-beae-f6240d45b950> <https://id.parliament.uk/schema/postCode> "SW1A 0AA" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
-    http_version: 
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/contactPointHasPostalAddress> <https://id.parliament.uk/uBuD8ZqA>
+        .\r\n<https://id.parliament.uk/uBuD8ZqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/PostalAddress> .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine1> \"House of Commons\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/addressLine2> \"London.\" .\r\n<https://id.parliament.uk/uBuD8ZqA>
+        <https://id.parliament.uk/schema/postCode> \"SW1A 0AA\" ."
+    http_version:
+  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_postal_addresses/Grom_Node_has_no_postal_addresses/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Parliament_Grom_Decorator_ContactPoint/_postal_addresses/Grom_Node_has_no_postal_addresses/returns_an_empty_array.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/80c2b596-494f-4dab-97ed-867729a40451
+    uri: http://localhost:3030/api/v1/person_by_id
     body:
       encoding: US-ASCII
       string: ''
@@ -19,61 +19,23 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 15 Mar 2018 14:39:43 GMT
       X-Content-Type-Options:
       - nosniff
-      Content-Type:
-      - application/n-triples; charset=utf-8
-      Etag:
-      - W/"4930bd447dd962cff4ecc318f37b3910"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8b031457-e0d5-4ba2-ad28-497fbe95a030
-      X-Runtime:
-      - '0.390380'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '22455'
     body:
       encoding: UTF-8
-      string: |
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Person> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personGivenName> "Person - givenName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/personFamilyName> "Person - familyName" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ConstituencyGroup> .
-        <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> <https://id.parliament.uk/schema/constituencyGroupName> "Walthamstow" .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/5d6e8e88-002c-48f7-837a-4b964dfe3e80> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/HouseSeat> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasConstituencyGroup> <https://id.parliament.uk/1b316bf7-2064-4cf7-921a-865f13d082e1> .
-        <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> <https://id.parliament.uk/schema/houseSeatHasHouse> <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Party> .
-        <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> <https://id.parliament.uk/schema/partyName> "Labour" .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipStartDate> "2010-05-06"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipEndDate> "2015-03-30"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/efbd7eec-da3e-47e6-a325-15a2d03a5635> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/House> .
-        <https://id.parliament.uk/4b77dd58-f6ba-4121-b521-c8ad70465f52> <https://id.parliament.uk/schema/houseName> "House of Commons" .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/partyMemberHasPartyMembership> <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/PartyMembership> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/21708d79-1bae-41b5-9648-fb3bd60c9aaf> <https://id.parliament.uk/schema/partyMembershipHasParty> <https://id.parliament.uk/f4e62fb8-2cf4-41b2-b7a3-7e621522a30d> .
-        <https://id.parliament.uk/80c2b596-494f-4dab-97ed-867729a40451> <https://id.parliament.uk/schema/memberHasParliamentaryIncumbency> <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint> .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/email> "example@parliament.uk" .
-        <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> <https://id.parliament.uk/schema/phoneNumber> "0123 4567 8901" .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/SeatIncumbency> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyStartDate> "2015-05-07"^^<http://www.w3.org/2001/XMLSchema#date> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/seatIncumbencyHasHouseSeat> <https://id.parliament.uk/cd7466be-0796-4044-9752-b5abfb8d7195> .
-        <https://id.parliament.uk/cae17778-79c2-42cb-8196-8e1d85d8c50f> <https://id.parliament.uk/schema/parliamentaryIncumbencyHasContactPoint> <https://id.parliament.uk/d4340898-79ef-4351-9674-49d61f36224d> .
+      string: "<https://id.parliament.uk/fy1cWNCD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ContactPoint>
+        .\r\n<https://id.parliament.uk/fy1cWNCD> <https://id.parliament.uk/schema/email>
+        \"emailaddress@parliament.uk\" .\r\n<https://id.parliament.uk/fy1cWNCD>
+        <https://id.parliament.uk/schema/phoneNumber> \"1234 567 8910\" ."
     http_version:
-  recorded_at: Tue, 18 Apr 2017 15:22:17 GMT
+  recorded_at: Thu, 15 Mar 2018 15:54:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/parliament/grom/decorator/contact_point_spec.rb
+++ b/spec/parliament/grom/decorator/contact_point_spec.rb
@@ -1,31 +1,30 @@
 require_relative '../../../spec_helper'
 
 describe Parliament::Grom::Decorator::ContactPoint, vcr: true do
-  let(:response) do
-    Parliament::Request::UrlRequest.new(base_url: 'http://localhost:3030',
-                                        builder: Parliament::Builder::NTripleResponseBuilder,
-                                        decorators: Parliament::Grom::Decorator).people('80c2b596-494f-4dab-97ed-867729a40451').get
-  end
-
   before(:each) do
-    @contact_point_nodes = response.filter('https://id.parliament.uk/schema/ContactPoint')
-  end
+    response = Parliament::Request::UrlRequest.new(base_url: 'http://localhost:3030/api/v1',
+      builder: Parliament::Builder::NTripleResponseBuilder,
+      decorators: Parliament::Grom::Decorator).person_by_id.get
+      @contact_point_nodes = response.filter('https://id.parliament.uk/schema/ContactPoint')
+    end
 
   describe '#postal_addresses' do
     context 'Grom::Node has all the required objects' do
       it 'returns the postal addresses for a Grom::Node object of type ContactPoint' do
-
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node.postal_addresses.size).to eq(1)
         expect(contact_point_node.postal_addresses.first.type).to eq('https://id.parliament.uk/schema/PostalAddress')
+      end
+
+      it 'returns an empty array for postal addresses with a full address that is less than the length limit' do
+        contact_point_node = @contact_point_nodes[0]
+        expect(contact_point_node.postal_addresses).to eq([])
       end
     end
 
     context 'Grom::Node has no postal addresses' do
       it 'returns an empty array' do
         contact_point_node = @contact_point_nodes[0]
-
         expect(contact_point_node.postal_addresses).to eq([])
       end
     end
@@ -35,27 +34,27 @@ describe Parliament::Grom::Decorator::ContactPoint, vcr: true do
     context 'Grom::Node has all the required objects' do
       it 'returns the email for a Grom::Node object of type ContactPoint' do
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node).to respond_to(:email)
-        expect(contact_point_node.email).to eq('person@parliament.uk')
+        expect(contact_point_node.email).to eq('emailaddress@parliament.uk')
       end
-    end
 
-    context 'Grom::Node has all the required objects' do
       it 'returns the email stripped of whitespace for a Grom::Node object of type ContactPoint' do
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node).to respond_to(:email)
-        expect(contact_point_node.email).to eq('person@parliament.uk')
+        expect(contact_point_node.email).to eq('emailaddress@parliament.uk')
+      end
+
+      it 'returns an empty string for email addresses that are less than the length limit' do
+        contact_point_node = @contact_point_nodes[0]
+        expect(contact_point_node).to respond_to(:email)
+        expect(contact_point_node.email).to eq('')
       end
     end
 
     context 'Grom::Node has no email' do
       it 'returns an empty string' do
         contact_point_node = @contact_point_nodes[0]
-
-        expect(contact_point_node).to respond_to(:email)
-        expect(contact_point_node.email).to eq('')
+          expect(contact_point_node.email).to eq('')
       end
     end
   end
@@ -64,16 +63,20 @@ describe Parliament::Grom::Decorator::ContactPoint, vcr: true do
     context 'Grom::Node has all the required objects' do
       it 'returns the phone number for a Grom::Node object of type ContactPoint' do
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node).to respond_to(:phone_number)
-        expect(contact_point_node.phone_number).to eq('0123 4567 8901')
+        expect(contact_point_node.phone_number).to eq('1234 567 8910')
+      end
+
+      it 'returns an empty string for phone numbers that are less than the length limit' do
+        contact_point_node = @contact_point_nodes[0]
+        expect(contact_point_node).to respond_to(:phone_number)
+        expect(contact_point_node.phone_number).to eq('')
       end
     end
 
     context 'Grom::Node has no phone number' do
       it 'returns an empty string' do
         contact_point_node = @contact_point_nodes[0]
-
         expect(contact_point_node).to respond_to(:phone_number)
         expect(contact_point_node.phone_number).to eq('')
       end
@@ -84,16 +87,20 @@ describe Parliament::Grom::Decorator::ContactPoint, vcr: true do
     context 'Grom::Node has all the required objects' do
       it 'returns the fax number for a Grom::Node object of type ContactPoint' do
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node).to respond_to(:fax_number)
-        expect(contact_point_node.fax_number).to eq('0123 4567 8901')
+        expect(contact_point_node.fax_number).to eq('1234 567 8910')
+      end
+
+      it 'returns an empty string for fax numbers that are less than the length limit' do
+        contact_point_node = @contact_point_nodes[0]
+        expect(contact_point_node).to respond_to(:fax_number)
+        expect(contact_point_node.fax_number).to eq('')
       end
     end
 
     context 'Grom::Node has no fax number' do
       it 'returns an empty string' do
         contact_point_node = @contact_point_nodes[0]
-
         expect(contact_point_node).to respond_to(:fax_number)
         expect(contact_point_node.fax_number).to eq('')
       end
@@ -104,18 +111,16 @@ describe Parliament::Grom::Decorator::ContactPoint, vcr: true do
     context 'Grom::Node has all the required objects' do
       it 'returns the object of type Person for a Grom::Node object of type ContactPoint' do
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node).to respond_to(:person)
         expect(contact_point_node.person.first.type).to eq('https://id.parliament.uk/schema/Person')
-        expect(contact_point_node.person.first.given_name).to eq('Person - givenName')
-        expect(contact_point_node.person.first.family_name).to eq('Person - familyName')
+        expect(contact_point_node.person.first.given_name).to eq('FirstName')
+        expect(contact_point_node.person.first.family_name).to eq('LastName')
       end
     end
 
     context 'Grom::Node has no person associated with it' do
       it 'returns an empty string' do
         contact_point_node = @contact_point_nodes[0]
-
         expect(contact_point_node).to respond_to(:person)
         expect(contact_point_node.person.size).to eq(0)
       end
@@ -126,7 +131,6 @@ describe Parliament::Grom::Decorator::ContactPoint, vcr: true do
     context 'Grom::Node has all the required objects' do
       it 'returns the object of type ParliamentaryIncumbency for a Grom::Node object of type ContactPoint' do
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node).to respond_to(:parliamentary_incumbency)
         expect(contact_point_node.parliamentary_incumbency.type).to eq('https://id.parliament.uk/schema/ParliamentaryIncumbency')
       end
@@ -135,7 +139,6 @@ describe Parliament::Grom::Decorator::ContactPoint, vcr: true do
     context 'Grom::Node has no parliamentary incumbency associated with it' do
       it 'returns nil' do
         contact_point_node = @contact_point_nodes.first
-
         expect(contact_point_node).to respond_to(:parliamentary_incumbency)
         expect(contact_point_node.parliamentary_incumbency).to be(nil)
       end


### PR DESCRIPTION
* Added check to ContactPoint decorators, to check if email, phone_number, fax_number and postal_addresses are over 3 characters in length
* Added tests
* This is a hack to remove "." and "-" addresses when these have been mistakenly entered into Mnis